### PR TITLE
홈페이지 UI 색상 변경 + 채팅 페이지 스크롤, UI

### DIFF
--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -78,6 +78,7 @@ class _ChatPageState extends State<ChatPage> {
           return Align(
             alignment: Alignment.topCenter,
             child: ListView.builder(
+                padding: EdgeInsets.fromLTRB(0,10,0,18),
                 shrinkWrap: true,
                 controller: scrollController,
                 reverse: true,
@@ -105,27 +106,48 @@ class _ChatPageState extends State<ChatPage> {
         ? Alignment.centerRight
         : Alignment.centerLeft;
 
-    return Container(
-      alignment: alignment,
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment:
-              (data['senderId'] == _firebaseAuth.currentUser!.uid)
-                  ? CrossAxisAlignment.end
-                  : CrossAxisAlignment.start,
-          mainAxisAlignment:
-              (data['senderId'] == _firebaseAuth.currentUser!.uid)
-                  ? MainAxisAlignment.end
-                  : MainAxisAlignment.start,
-          children: [
-            Text(data['senderEmail']),
-            const SizedBox(height: 5),
-            ChatBubble(message: data['message']),
-          ],
-        ),
-      ),
-    );
+    return data['senderId'] != _firebaseAuth.currentUser!.uid
+        ? Container(
+            alignment: alignment,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(8, 8, 180.0, 8),
+              child: Column(
+                crossAxisAlignment:
+                (data['senderId'] == _firebaseAuth.currentUser!.uid)
+                    ? CrossAxisAlignment.end
+                    : CrossAxisAlignment.start,
+                mainAxisAlignment:
+                (data['senderId'] == _firebaseAuth.currentUser!.uid)
+                    ? MainAxisAlignment.end
+                    : MainAxisAlignment.start,
+                children: [
+                  Text(data['senderEmail']),
+                  const SizedBox(height: 5),
+                  ChatBubble(message: data['message']),
+                ],
+              ),
+            ),
+          )
+        : Container(
+            alignment: alignment,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(180.0, 5, 5, 5),
+              child: Column(
+                crossAxisAlignment:
+                (data['senderId'] == _firebaseAuth.currentUser!.uid)
+                    ? CrossAxisAlignment.end
+                    : CrossAxisAlignment.start,
+                mainAxisAlignment:
+                (data['senderId'] == _firebaseAuth.currentUser!.uid)
+                    ? MainAxisAlignment.end
+                    : MainAxisAlignment.start,
+                children: [
+                  //const SizedBox(height: 2),
+                  ChatBubble(message: data['message']),
+                ],
+              ),
+            ),
+          );
   }
 
   // build message input

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -24,6 +24,7 @@ class _ChatPageState extends State<ChatPage> {
   final TextEditingController _messageController = TextEditingController();
   final ChatService _chatService = ChatService();
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
+  final scrollController = ScrollController();
 
   void sendMessage() async {
     // only send message if there is something to send
@@ -33,12 +34,17 @@ class _ChatPageState extends State<ChatPage> {
 
       //clear the text controller after sending the message
       _messageController.clear();
+      scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.fastLinearToSlowEaseIn,);
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: true, // 가상 키보드 활성화 시 메세지 내용 가리지 않게
       appBar: AppBar(
         backgroundColor: Colors.blue,
         title: Text(widget.receiverUserEmail, style: TextStyle(color: Colors.white,)),
@@ -69,12 +75,24 @@ class _ChatPageState extends State<ChatPage> {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Text('Loading..');
           }
-          return ListView(
-            children: snapshot.data!.docs
-                .map((document) => _buildMessageItem(document))
-                .toList(),
+          return Align(
+            alignment: Alignment.topCenter,
+            child: ListView.builder(
+                shrinkWrap: true,
+                controller: scrollController,
+                reverse: true,
+                itemCount: 1,
+                itemBuilder: (ctx, index) {
+                  return Column(
+                    children: snapshot.data!.docs
+                        .map((document) => _buildMessageItem(document))
+                        .toList(),
+                  );
+                }
+            ),
           );
-        });
+        }
+      );
   }
 
   // build message item

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:chat_app_tutorial/pages/chat_page.dart';
 import 'package:chat_app_tutorial/services/auth/auth_service.dart';
 import 'package:chat_app_tutorial/pages/Screen2.dart';
@@ -39,7 +41,7 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Colors.blue,
+        backgroundColor: Colors.white,
         scrolledUnderElevation: 0,
         title: IndexedStack(
           index: _selectedIndex,
@@ -47,25 +49,25 @@ class _HomePageState extends State<HomePage> {
             Row(
               children: [
                 SizedBox(width: 15,),
-                Icon(Icons.cloud, color: Colors.white70,size: 30,),
+                Icon(Icons.cloud, color: Colors.lightBlue[200],size: 30,),
                 SizedBox(width: 5,),
-                Text("Home", style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold,)),
+                Text("Home", style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold,)),
               ],
             ),
             Row(
               children: [
                 SizedBox(width: 15,),
-                Icon(Icons.cloud, color: Colors.white70,size: 30,),
+                Icon(Icons.cloud, color: Colors.lightBlue[200],size: 30,),
                 SizedBox(width: 5,),
-                Text("Chats", style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold,)),
+                Text("Chats", style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold,)),
               ],
             ),
             Row(
               children: [
                 SizedBox(width: 15,),
-                Icon(Icons.cloud, color: Colors.white70,size: 30,),
+                Icon(Icons.cloud, color: Colors.lightBlue[200],size: 30,),
                 SizedBox(width: 5,),
-                Text("Settings", style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold,)),
+                Text("Settings", style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold,)),
               ],
             ),
           ],
@@ -78,14 +80,14 @@ class _HomePageState extends State<HomePage> {
               Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.add_box_outlined, color: Colors.white, size: 30, ),
+                  Icon(Icons.add_box_outlined, color: Colors.black, size: 30, ),
                 ],
               ),
               // Page 2
               Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.add_circle_outline_outlined, color: Colors.white, size: 30, ),
+                  Icon(Icons.add_circle_outline_outlined, color: Colors.black, size: 30, ),
                 ],
               ),
               // Page 3
@@ -94,8 +96,8 @@ class _HomePageState extends State<HomePage> {
                 children: [
                   IconButton(
                     onPressed: signOut,
-                    icon: const Icon(Icons.logout),
-                    color: Colors.white,
+                    icon: const Icon(Icons.logout,),
+                    color: Colors.black,
                   ),
                 ],
               ),


### PR DESCRIPTION
home_page.dart
- body 부분과 통일성을 위해 AppBar 배경색 흰색으로 변경
- 배경색에 맞게 글자, 아이콘 색상 변경

chat_page.dart
- 채팅 페이지가 항상 맨 아래(최신 메세지)로 스크롤되어 있게 설정
- 나(현재 사용자)의 메세지가 입력되면 스크롤 맨 아래로 내리도록 설정
- 채팅페이지 UI (사용자 닉네임 안보이게 변경, 기타 여백 수정)